### PR TITLE
Add IF NOT EXISTS to table create statements.

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	statements := [3]string{
 		// CREATE the messages table
-		"CREATE TABLE messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
+		"CREATE TABLE IF NOT EXISTS messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
 		// INSERT a row into the messages table
 		"INSERT INTO messages (message) VALUES ('Hello world!')",
 		// SELECT a row from the messages table

--- a/java/app/src/main/java/example/app/App.java
+++ b/java/app/src/main/java/example/app/App.java
@@ -28,7 +28,7 @@ public class App {
 
     private static String[] statements = {
         // CREATE the messages table
-        "CREATE TABLE messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
+        "CREATE TABLE IF NOT EXISTS messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
         // INSERT a row into the messages table
         "INSERT INTO messages (message) VALUES ('Hello world!')",
         // SELECT a row from the messages table

--- a/node/app.js
+++ b/node/app.js
@@ -5,7 +5,7 @@ const { Client } = require("pg");
 
   const statements = [
     // CREATE the messages table
-    "CREATE TABLE messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
+    "CREATE TABLE IF NOT EXISTS messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
     // INSERT a row into the messages table
     "INSERT INTO messages (message) VALUES ('Hello world!')",
     // SELECT a row from the messages table

--- a/python/main.py
+++ b/python/main.py
@@ -20,7 +20,7 @@ def main():
 
     statements = [
         # CREATE the messages table
-        "CREATE TABLE messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
+        "CREATE TABLE IF NOT EXISTS messages (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), message STRING)",
         # INSERT a row into the messages table
         "INSERT INTO messages (message) VALUES ('Hello world!')",
         # SELECT a row from the messages table

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.3


### PR DESCRIPTION
Adding `CREATE TABLE IF NOT EXISTS` if users want to run other language samples, or rerun the current sample. The Python example would throw a transaction error without it if `messages` already exists.

Also bumping the version of psycopg2-binary so it uses a [wheel version](https://github.com/psycopg/psycopg2/issues/1448#issuecomment-1105844036).