### PR TITLE
Add application_name parameter to the Python connection string

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -16,7 +16,7 @@ def exec_statement(conn, stmt):
 def main():
 
     # Connect to CockroachDB
-    connection = psycopg2.connect(os.environ['DATABASE_URL'], application_name="$ docs_quickstart_python")
+    connection = psycopg2.connect(dsn=os.environ["DATABASE_URL"], application_name="$ docs_quickstart_python")
 
     statements = [
         # CREATE the messages table


### PR DESCRIPTION
This will help us more accurately identify docs-attributed
Serverless clusters and their usage over time.

Part of DOC-4617.