### PR TITLE
Add application_name parameter to the Node connection string

### DIFF
--- a/node/app.js
+++ b/node/app.js
@@ -1,7 +1,10 @@
 const { Client } = require("pg");
 
 (async () => {
-  const client = new Client(process.env.DATABASE_URL);
+  const client = new Client({
+    connectionString: process.env.DATABASE_URL,
+    application_name: "$ docs_quickstart_node"
+  });
 
   const statements = [
     // CREATE the messages table


### PR DESCRIPTION
This will help us more accurately identify docs-attributed
Serverless clusters and their usage over time.

Part of DOC-4617.